### PR TITLE
unsupported options

### DIFF
--- a/src/abp-filter-parser.js
+++ b/src/abp-filter-parser.js
@@ -124,7 +124,7 @@ export function parseOptions(input) {
 
       // unsupported options: this can include request types since they
       // fall through the if(elementTypeMaskMap) above
-      if (!(supportedOptions[option] && elementTypeMaskMap.has(option)) {
+      if (!(supportedOptions[option] && elementTypeMaskMap.has(option))) {
           if (!output.unsupported) {
               output.unsupported = []
           }

--- a/src/abp-filter-parser.js
+++ b/src/abp-filter-parser.js
@@ -551,7 +551,7 @@ function hasMatchingFilters(filterList, parsedFilterData, input, contextParams, 
     // debug logging for matched filters. To turn this on run this in the extension console
     // abp.setFilterDebugging(true)
     if (filterDebugging) {
-        console.log("FOUND FILTER\n" + "Request: " + input + "\n" + "Filter: " + foundFilter) 
+        console.log("FOUND FILTER\n" + "Request: " + input + "\n" + "Filter: " + JSON.stringify(foundFilter))
     }
 
     // increment the count of matches

--- a/src/abp-filter-parser.js
+++ b/src/abp-filter-parser.js
@@ -107,7 +107,7 @@ export function parseOptions(input) {
     binaryOptions: new Set(),
   };
 
-  let supportedOptions = {'third-party': 1}
+  let optionSupport = {'third-party': 1, '~third-party': 0}
 
   input.split(',').forEach((option) => {
     option = option.trim();
@@ -126,7 +126,7 @@ export function parseOptions(input) {
 
       // unsupported options: this can include unsupported request types since they
       // fall through the if(elementTypeMaskMap) above
-      if (!(supportedOptions[optionWithoutPrefix] || elementTypeMaskMap.has(optionWithoutPrefix))) {
+      if (!(optionSupport[option] || elementTypeMaskMap.has(optionWithoutPrefix))) {
           if (!output.unsupported) {
               output.unsupported = []
           }

--- a/src/abp-filter-parser.js
+++ b/src/abp-filter-parser.js
@@ -124,8 +124,11 @@ export function parseOptions(input) {
 
       // unsupported options: this can include request types since they
       // fall through the if(elementTypeMaskMap) above
-      if (!supportedOptions[option]) {
-          output.unsupported = true
+      if (!(supportedOptions[option] && elementTypeMaskMap.has(option)) {
+          if (!output.unsupported) {
+              output.unsupported = []
+          }
+          output.unsupported.push(option)
       }
 
       output.binaryOptions.add(option);
@@ -455,7 +458,7 @@ function matchOptions(parsedFilterData, input, contextParams = {}) {
  * Given an individual parsed filter data determines if the input url should block.
  */
 export function matchesFilter(parsedFilterData, input, contextParams = {}, cachedInputData = {}) {
-  if (parsedFilterData.options && parsedFilterData.options.unsuported) {
+  if (parsedFilterData.options && parsedFilterData.options.unsupported) {
       return false
   }
 

--- a/src/abp-filter-parser.js
+++ b/src/abp-filter-parser.js
@@ -18,6 +18,9 @@ export const elementTypes = {
   OTHER: 0o400,
 };
 
+let filterDebugging = false
+export let setFilterDebugging = function(debug) { if(debug) filterDebugging = debug}
+
 // Maximum number of cached entries to keep for subsequent lookups
 const maxCached = 100;
 
@@ -26,7 +29,6 @@ const maxUrlChars = 100;
 
 // Exact size for fingerprints, if you change also change fingerprintRegexs
 const fingerprintSize = 8;
-
 // Regexes used to create fingerprints
 // There's more than one because sometimes a fingerprint is determined to be a bad
 // one and would lead to a lot of collisions in the bloom filter). In those cases
@@ -545,6 +547,12 @@ function hasMatchingFilters(filterList, parsedFilterData, input, contextParams, 
   const foundFilter = filterList.find(parsedFilterData2 =>
     matchesFilter(parsedFilterData2, input, contextParams, cachedInputData));
   if (foundFilter && cachedInputData.matchedFilters && foundFilter.rawFilter) {
+
+    // debug logging for matched filters. To turn this on run this in the extension console
+    // abp.setFilterDebugging(true)
+    if (filterDebugging) {
+        console.log("FOUND FILTER\n" + "Request: " + input + "\n" + "Filter: " + foundFilter) 
+    }
 
     // increment the count of matches
     // we store an extra object and a count so that in the future

--- a/src/abp-filter-parser.js
+++ b/src/abp-filter-parser.js
@@ -551,7 +551,7 @@ function hasMatchingFilters(filterList, parsedFilterData, input, contextParams, 
     // debug logging for matched filters. To turn this on run this in the extension console
     // abp.setFilterDebugging(true)
     if (filterDebugging) {
-        console.log("FOUND FILTER\n" + "Request: " + input + "\n" + "Filter: " + JSON.stringify(foundFilter))
+        console.log("Matched Filter\n" + "List name: " + contextParams.listName "\n" + "Request: " + input + "\n" + "Filter: " + JSON.stringify(foundFilter))
     }
 
     // increment the count of matches

--- a/src/abp-filter-parser.js
+++ b/src/abp-filter-parser.js
@@ -551,7 +551,7 @@ function hasMatchingFilters(filterList, parsedFilterData, input, contextParams, 
     // debug logging for matched filters. To turn this on run this in the extension console
     // abp.setFilterDebugging(true)
     if (filterDebugging) {
-        console.log("Matched Filter\n" + "List name: " + contextParams.listName "\n" + "Request: " + input + "\n" + "Filter: " + JSON.stringify(foundFilter))
+        console.log(`Matched Filter\nList name: ${contextParams.listName}\nRequest: ${input}\n"Filter: ${JSON.stringify(foundFilter)}`)
     }
 
     // increment the count of matches

--- a/src/abp-filter-parser.js
+++ b/src/abp-filter-parser.js
@@ -104,6 +104,9 @@ export function parseOptions(input) {
   let output = {
     binaryOptions: new Set(),
   };
+
+  let supportedOptions = {'third-party': 1}
+
   input.split(',').forEach((option) => {
     option = option.trim();
     if (option.startsWith('domain=')) {
@@ -118,7 +121,15 @@ export function parseOptions(input) {
           output.elementTypeMask |= elementTypeMaskMap.get(optionWithoutPrefix);
         }
       }
+
+      // unsupported options: this can include request types since they
+      // fall through the if(elementTypeMaskMap) above
+      if (!supportedOptions[option]) {
+          output.unsupported = true
+      }
+
       output.binaryOptions.add(option);
+
     }
   });
   return output;
@@ -444,6 +455,10 @@ function matchOptions(parsedFilterData, input, contextParams = {}) {
  * Given an individual parsed filter data determines if the input url should block.
  */
 export function matchesFilter(parsedFilterData, input, contextParams = {}, cachedInputData = {}) {
+  if (parsedFilterData.unsuported) {
+      return false
+  }
+
   if (!matchOptions(parsedFilterData, input, contextParams)) {
     return false;
   }

--- a/src/abp-filter-parser.js
+++ b/src/abp-filter-parser.js
@@ -122,9 +122,9 @@ export function parseOptions(input) {
         }
       }
 
-      // unsupported options: this can include request types since they
+      // unsupported options: this can include unsupported request types since they
       // fall through the if(elementTypeMaskMap) above
-      if (!(supportedOptions[option] && elementTypeMaskMap.has(option))) {
+      if (!(supportedOptions[option] || elementTypeMaskMap.has(option))) {
           if (!output.unsupported) {
               output.unsupported = []
           }

--- a/src/abp-filter-parser.js
+++ b/src/abp-filter-parser.js
@@ -551,7 +551,7 @@ function hasMatchingFilters(filterList, parsedFilterData, input, contextParams, 
     // debug logging for matched filters. To turn this on run this in the extension console
     // abp.setFilterDebugging(true)
     if (filterDebugging) {
-        console.log(`Matched Filter\nList name: ${contextParams.listName}\nRequest: ${input}\n"Filter: ${JSON.stringify(foundFilter)}`)
+        console.log(`Matched Filter\nList name: ${contextParams.listName}\nRequest: ${input}\nFilter: ${JSON.stringify(foundFilter)}`)
     }
 
     // increment the count of matches

--- a/src/abp-filter-parser.js
+++ b/src/abp-filter-parser.js
@@ -455,7 +455,7 @@ function matchOptions(parsedFilterData, input, contextParams = {}) {
  * Given an individual parsed filter data determines if the input url should block.
  */
 export function matchesFilter(parsedFilterData, input, contextParams = {}, cachedInputData = {}) {
-  if (parsedFilterData.unsuported) {
+  if (parsedFilterData.options && parsedFilterData.options.unsuported) {
       return false
   }
 

--- a/src/abp-filter-parser.js
+++ b/src/abp-filter-parser.js
@@ -124,7 +124,7 @@ export function parseOptions(input) {
 
       // unsupported options: this can include unsupported request types since they
       // fall through the if(elementTypeMaskMap) above
-      if (!(supportedOptions[option] || elementTypeMaskMap.has(option))) {
+      if (!(supportedOptions[optionWithoutPrefix] || elementTypeMaskMap.has(optionWithoutPrefix))) {
           if (!output.unsupported) {
               output.unsupported = []
           }


### PR DESCRIPTION
I'm settings a `unsupported` flag in filters that use options or request types that we don't support. 
After this change the following unsupported types will be flagged in easylist and easyprivacy.
```
media: 3
popup: 1121
webrtc: 126
websocket: 132
~collapse: 1
~ping: 1
```

I also added a filter debugging option. `abp.setFilterDebugging(true)`

Testing:
1. Update package.json in your extension
`"abp-filter-parser": "git://github.com/duckduckgo/abp-filter-parser.git#jd/unsupported-options",`
2. Turn off the whitelist
`whitelists.trackersWhitelist.isLoaded = false`
3. got to http://sporting.pt. We were whitelisting a filter with a websocket option that was breaking the site. The filter is marked as unsupported now. 

Parse a filter with an unsupported option. Here's an example of how to easily do that from the console.
<img width="824" alt="screen shot 2018-02-09 at 3 04 34 pm" src="https://user-images.githubusercontent.com/1882892/36052377-b1dc9c6a-0daa-11e8-98d8-487e87b4fb70.png">
 